### PR TITLE
MLS XSLT: SPIS regex not case insensitive

### DIFF
--- a/phive-rules-peppol/src/main/resources/external/schematron/mls/1.0.0/xslt/peppol-mls-1.0.0.xslt
+++ b/phive-rules-peppol/src/main/resources/external/schematron/mls/1.0.0/xslt/peppol-mls-1.0.0.xslt
@@ -322,9 +322,9 @@
 
 		<!--ASSERT -->
 <xsl:choose>
-      <xsl:when test="matches(normalize-space(cac:SenderParty/cbc:EndpointID), $regex_spis)" />
+      <xsl:when test="matches(normalize-space(upper-case(cac:SenderParty/cbc:EndpointID)), $regex_spis)" />
       <xsl:otherwise>
-        <svrl:failed-assert test="matches(normalize-space(cac:SenderParty/cbc:EndpointID), $regex_spis)">
+        <svrl:failed-assert test="matches(normalize-space(upper-case(cac:SenderParty/cbc:EndpointID)), $regex_spis)">
           <xsl:attribute name="id">SCH-MLS-09</xsl:attribute>
           <xsl:attribute name="flag">fatal</xsl:attribute>
           <xsl:attribute name="location">
@@ -399,9 +399,9 @@
 
 		<!--ASSERT -->
 <xsl:choose>
-      <xsl:when test="matches(normalize-space(cac:ReceiverParty/cbc:EndpointID), $regex_spis)" />
+      <xsl:when test="matches(normalize-space(upper-case(cac:ReceiverParty/cbc:EndpointID)), $regex_spis)" />
       <xsl:otherwise>
-        <svrl:failed-assert test="matches(normalize-space(cac:ReceiverParty/cbc:EndpointID), $regex_spis)">
+        <svrl:failed-assert test="matches(normalize-space(upper-case(cac:ReceiverParty/cbc:EndpointID)), $regex_spis)">
           <xsl:attribute name="id">SCH-MLS-14</xsl:attribute>
           <xsl:attribute name="flag">fatal</xsl:attribute>
           <xsl:attribute name="location">


### PR DESCRIPTION
The regex provided by OpenPeppol does not allow lowercase characters, but the documentation also indicates that Peppol Participant Identifiers must be treated case insensitive.

Also, when we create a PeppolParticipantIdentifier, the value is put in lower case, so the validation would wrongly fail for any participant that have lower case characters in the value.

I'm not sure it is the best way to do this, as I presume the .xslt was auto generated.