### PR TITLE
Trim phive-rules-peppol runtime dependencies

### DIFF
--- a/phive-rules-peppol/pom.xml
+++ b/phive-rules-peppol/pom.xml
@@ -65,17 +65,13 @@
       <version>${ph-ubl.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.helger.cii</groupId>
-      <artifactId>ph-cii-d16b</artifactId>
-      <version>${ph-cii.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.helger.phive.rules</groupId>
       <artifactId>phive-rules-api</artifactId>
     </dependency>
     <dependency>
       <groupId>com.helger.phive.rules</groupId>
       <artifactId>phive-rules-en16931</artifactId>
+      <scope>test</scope>
     </dependency>
     
     <dependency>


### PR DESCRIPTION
Closes #81.

`phive-rules-peppol` does not use `ph-cii-d16b` from production code, and it uses `phive-rules-en16931` only from tests. This removes the former and scopes the latter to tests, keeping both off downstream runtime classpaths.

This is intentionally only a POM correction; validation sources and resources are unchanged.

Verified with:

- `mvn -pl phive-rules-peppol -am test`
- `mvn -pl phive-rules-peppol dependency:tree -Dscope=runtime -Dincludes=com.helger.cii:ph-cii-d16b,com.helger.phive.rules:phive-rules-en16931` (neither artifact appears)