### PR TITLE
Add billing-only Peppol registration

### DIFF
--- a/phive-rules-peppol/src/main/java/com/helger/phive/peppol/PeppolValidation2025_05.java
+++ b/phive-rules-peppol/src/main/java/com/helger/phive/peppol/PeppolValidation2025_05.java
@@ -82,34 +82,24 @@ public final class PeppolValidation2025_05
     return PeppolValidation2025_05.class.getClassLoader ();
   }
 
-  public static void init (@NonNull final IValidationExecutorSetRegistry <IValidationSourceXML> aRegistry)
+  /**
+   * Register only the Peppol BIS Billing validation execution sets.
+   *
+   * @param aRegistry
+   *        The registry to add the artefacts. May not be <code>null</code>.
+   */
+  public static void initBilling (@NonNull final IValidationExecutorSetRegistry <IValidationSourceXML> aRegistry)
   {
     ValueEnforcer.notNull (aRegistry, "Registry");
 
     final String sVersion = " (" + VERSION_STR + ")";
     // See https://docs.peppol.eu/poacc/billing/3.0/release-notes/
     final String sAkaVersionBilling = " (aka BIS Billing 3.0.19)";
-    // See https://docs.peppol.eu/poacc/upgrade-3/release-notes/
-    final String sAkaVersionBIS = " (aka BIS 3.0.15)";
 
     final String PREFIX_XSLT = "external/schematron/openpeppol/" + VERSION_STR + "/xslt/";
     final IReadableResource INVOICE_UBL_CEN = new ClassPathResource (PREFIX_XSLT + "CEN-EN16931-UBL.xslt", _getCL ());
     final IReadableResource INVOICE_UBL_PEPPOL = new ClassPathResource (PREFIX_XSLT + "PEPPOL-EN16931-UBL.xslt",
                                                                         _getCL ());
-    final IReadableResource ORDER = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T01.xslt", _getCL ());
-    final IReadableResource DESPATCH_ADVICE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T16.xslt", _getCL ());
-    final IReadableResource CATALOGUE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T19.xslt", _getCL ());
-    final IReadableResource CATALOGUE_RESPONSE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T58.xslt", _getCL ());
-    final IReadableResource MLR = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T71.xslt", _getCL ());
-    final IReadableResource ORDER_RESPONSE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T76.xslt", _getCL ());
-    final IReadableResource PUNCH_OUT = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T77.xslt", _getCL ());
-    final IReadableResource ORDER_AGREEMENT = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T110.xslt", _getCL ());
-    final IReadableResource INVOICE_MESSAGE_RESPONSE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T111.xslt",
-                                                                              _getCL ());
-    final IReadableResource ORDER_CHANGE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T114.xslt", _getCL ());
-    final IReadableResource ORDER_CANCELLATION = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T115.xslt", _getCL ());
-    final IReadableResource ORDER_RESPONSE_ADVANCED = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T116.xslt",
-                                                                             _getCL ());
 
     VesXmlBuilder.builder ()
                  .vesID (VID_OPENPEPPOL_INVOICE_UBL_V3)
@@ -129,11 +119,38 @@ public final class PeppolValidation2025_05
                  .addSchematron (PhiveRulesUBLHelper.createXSLT_UBL21 (INVOICE_UBL_CEN))
                  .addSchematron (PhiveRulesUBLHelper.createXSLT_UBL21 (INVOICE_UBL_PEPPOL))
                  .registerInto (aRegistry);
+  }
+
+  public static void init (@NonNull final IValidationExecutorSetRegistry <IValidationSourceXML> aRegistry)
+  {
+    ValueEnforcer.notNull (aRegistry, "Registry");
+    initBilling (aRegistry);
+
+    final String sVersion = " (" + VERSION_STR + ")";
+    // See https://docs.peppol.eu/poacc/upgrade-3/release-notes/
+    final String sAkaVersionBIS = " (aka BIS 3.0.15)";
+
+    final String PREFIX_XSLT = "external/schematron/openpeppol/" + VERSION_STR + "/xslt/";
+    final IReadableResource ORDER = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T01.xslt", _getCL ());
+    final IReadableResource DESPATCH_ADVICE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T16.xslt", _getCL ());
+    final IReadableResource CATALOGUE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T19.xslt", _getCL ());
+    final IReadableResource CATALOGUE_RESPONSE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T58.xslt", _getCL ());
+    final IReadableResource MLR = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T71.xslt", _getCL ());
+    final IReadableResource ORDER_RESPONSE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T76.xslt", _getCL ());
+    final IReadableResource PUNCH_OUT = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T77.xslt", _getCL ());
+    final IReadableResource ORDER_AGREEMENT = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T110.xslt", _getCL ());
+    final IReadableResource INVOICE_MESSAGE_RESPONSE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T111.xslt",
+                                                                              _getCL ());
+    final IReadableResource ORDER_CHANGE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T114.xslt", _getCL ());
+    final IReadableResource ORDER_CANCELLATION = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T115.xslt", _getCL ());
+    final IReadableResource ORDER_RESPONSE_ADVANCED = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T116.xslt",
+                                                                             _getCL ());
+
     // aRegistry.registerValidationExecutorSet (ValidationExecutorSet.create
     // (VID_OPENPEPPOL_INVOICE_CII_V3,
     // "OpenPeppol CII Invoice" +
     // sVersion +
-    // sAkaVersionBilling,
+    // " (aka BIS Billing 3.0.19)",
     // _createStatus (bNotDeprecated),
     // ValidationExecutorXSD.create (CCIID16B.getXSDResource ()),
     // _createXsltCII (INVOICE_CII_CEN),

--- a/phive-rules-peppol/src/main/java/com/helger/phive/peppol/PeppolValidation2025_11.java
+++ b/phive-rules-peppol/src/main/java/com/helger/phive/peppol/PeppolValidation2025_11.java
@@ -82,34 +82,24 @@ public final class PeppolValidation2025_11
     return PeppolValidation2025_11.class.getClassLoader ();
   }
 
-  public static void init (@NonNull final IValidationExecutorSetRegistry <IValidationSourceXML> aRegistry)
+  /**
+   * Register only the Peppol BIS Billing validation execution sets.
+   *
+   * @param aRegistry
+   *        The registry to add the artefacts. May not be <code>null</code>.
+   */
+  public static void initBilling (@NonNull final IValidationExecutorSetRegistry <IValidationSourceXML> aRegistry)
   {
     ValueEnforcer.notNull (aRegistry, "Registry");
 
     final String sVersion = " (" + VERSION_STR + ")";
     // See https://docs.peppol.eu/poacc/billing/3.0/release-notes/
     final String sAkaVersionBilling = " (aka BIS Billing 3.0.20)";
-    // See https://docs.peppol.eu/poacc/upgrade-3/release-notes/
-    final String sAkaVersionBIS = " (aka BIS 3.0.16)";
 
     final String PREFIX_XSLT = "external/schematron/openpeppol/" + VERSION_STR + "/xslt/";
     final IReadableResource INVOICE_UBL_CEN = new ClassPathResource (PREFIX_XSLT + "CEN-EN16931-UBL.xslt", _getCL ());
     final IReadableResource INVOICE_UBL_PEPPOL = new ClassPathResource (PREFIX_XSLT + "PEPPOL-EN16931-UBL.xslt",
                                                                         _getCL ());
-    final IReadableResource ORDER = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T01.xslt", _getCL ());
-    final IReadableResource DESPATCH_ADVICE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T16.xslt", _getCL ());
-    final IReadableResource CATALOGUE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T19.xslt", _getCL ());
-    final IReadableResource CATALOGUE_RESPONSE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T58.xslt", _getCL ());
-    final IReadableResource MLR = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T71.xslt", _getCL ());
-    final IReadableResource ORDER_RESPONSE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T76.xslt", _getCL ());
-    final IReadableResource PUNCH_OUT = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T77.xslt", _getCL ());
-    final IReadableResource ORDER_AGREEMENT = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T110.xslt", _getCL ());
-    final IReadableResource INVOICE_MESSAGE_RESPONSE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T111.xslt",
-                                                                              _getCL ());
-    final IReadableResource ORDER_CHANGE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T114.xslt", _getCL ());
-    final IReadableResource ORDER_CANCELLATION = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T115.xslt", _getCL ());
-    final IReadableResource ORDER_RESPONSE_ADVANCED = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T116.xslt",
-                                                                             _getCL ());
 
     VesXmlBuilder.builder ()
                  .vesID (VID_OPENPEPPOL_INVOICE_UBL_V3)
@@ -129,11 +119,38 @@ public final class PeppolValidation2025_11
                  .addSchematron (PhiveRulesUBLHelper.createXSLT_UBL21 (INVOICE_UBL_CEN))
                  .addSchematron (PhiveRulesUBLHelper.createXSLT_UBL21 (INVOICE_UBL_PEPPOL))
                  .registerInto (aRegistry);
+  }
+
+  public static void init (@NonNull final IValidationExecutorSetRegistry <IValidationSourceXML> aRegistry)
+  {
+    ValueEnforcer.notNull (aRegistry, "Registry");
+    initBilling (aRegistry);
+
+    final String sVersion = " (" + VERSION_STR + ")";
+    // See https://docs.peppol.eu/poacc/upgrade-3/release-notes/
+    final String sAkaVersionBIS = " (aka BIS 3.0.16)";
+
+    final String PREFIX_XSLT = "external/schematron/openpeppol/" + VERSION_STR + "/xslt/";
+    final IReadableResource ORDER = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T01.xslt", _getCL ());
+    final IReadableResource DESPATCH_ADVICE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T16.xslt", _getCL ());
+    final IReadableResource CATALOGUE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T19.xslt", _getCL ());
+    final IReadableResource CATALOGUE_RESPONSE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T58.xslt", _getCL ());
+    final IReadableResource MLR = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T71.xslt", _getCL ());
+    final IReadableResource ORDER_RESPONSE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T76.xslt", _getCL ());
+    final IReadableResource PUNCH_OUT = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T77.xslt", _getCL ());
+    final IReadableResource ORDER_AGREEMENT = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T110.xslt", _getCL ());
+    final IReadableResource INVOICE_MESSAGE_RESPONSE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T111.xslt",
+                                                                              _getCL ());
+    final IReadableResource ORDER_CHANGE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T114.xslt", _getCL ());
+    final IReadableResource ORDER_CANCELLATION = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T115.xslt", _getCL ());
+    final IReadableResource ORDER_RESPONSE_ADVANCED = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T116.xslt",
+                                                                             _getCL ());
+
     // aRegistry.registerValidationExecutorSet (ValidationExecutorSet.create
     // (VID_OPENPEPPOL_INVOICE_CII_V3,
     // "OpenPeppol CII Invoice" +
     // sVersion +
-    // sAkaVersionBilling,
+    // " (aka BIS Billing 3.0.20)",
     // _createStatus (bNotDeprecated),
     // ValidationExecutorXSD.create (CCIID16B.getXSDResource ()),
     // _createXsltCII (INVOICE_CII_CEN),

--- a/phive-rules-peppol/src/main/java/com/helger/phive/peppol/PeppolValidation2026_03.java
+++ b/phive-rules-peppol/src/main/java/com/helger/phive/peppol/PeppolValidation2026_03.java
@@ -57,7 +57,13 @@ public final class PeppolValidation2026_03
     return PeppolValidation2026_03.class.getClassLoader ();
   }
 
-  public static void init (@NonNull final IValidationExecutorSetRegistry <IValidationSourceXML> aRegistry)
+  /**
+   * Register the Peppol BIS Self-Billing validation execution sets.
+   *
+   * @param aRegistry
+   *        The registry to add the artefacts. May not be <code>null</code>.
+   */
+  public static void initBilling (@NonNull final IValidationExecutorSetRegistry <IValidationSourceXML> aRegistry)
   {
     ValueEnforcer.notNull (aRegistry, "Registry");
 
@@ -84,5 +90,10 @@ public final class PeppolValidation2026_03
                  .addSchematron (PhiveRulesUBLHelper.createXSLT_UBL21 (aCENSB))
                  .addSchematron (PhiveRulesUBLHelper.createXSLT_UBL21 (aPeppolSB))
                  .registerInto (aRegistry);
+  }
+
+  public static void init (@NonNull final IValidationExecutorSetRegistry <IValidationSourceXML> aRegistry)
+  {
+    initBilling (aRegistry);
   }
 }

--- a/phive-rules-peppol/src/main/java/com/helger/phive/peppol/PeppolValidation2026_05.java
+++ b/phive-rules-peppol/src/main/java/com/helger/phive/peppol/PeppolValidation2026_05.java
@@ -86,7 +86,13 @@ public final class PeppolValidation2026_05
     return PeppolValidation2026_05.class.getClassLoader ();
   }
 
-  public static void init (@NonNull final IValidationExecutorSetRegistry <IValidationSourceXML> aRegistry)
+  /**
+   * Register only the Peppol BIS Billing and Self-Billing validation execution sets.
+   *
+   * @param aRegistry
+   *        The registry to add the artefacts. May not be <code>null</code>.
+   */
+  public static void initBilling (@NonNull final IValidationExecutorSetRegistry <IValidationSourceXML> aRegistry)
   {
     ValueEnforcer.notNull (aRegistry, "Registry");
 
@@ -95,8 +101,6 @@ public final class PeppolValidation2026_05
     final String sAkaVersionBilling = " (aka BIS Billing 3.0.21)";
     // See https://docs.peppol.eu/poacc/self-billing/3.0/release-notes/
     final String sAkaVersionSelfBilling = " (aka BIS Self-Billing 3.0.2)";
-    // See https://docs.peppol.eu/poacc/upgrade-3/release-notes/
-    final String sAkaVersionBIS = " (aka BIS 3.0.17)";
 
     final String PREFIX_XSLT = "external/schematron/openpeppol/" + VERSION_STR + "/xslt/";
     final IReadableResource INVOICE_UBL_CEN = new ClassPathResource (PREFIX_XSLT + "CEN-EN16931-UBL.xslt", _getCL ());
@@ -104,20 +108,6 @@ public final class PeppolValidation2026_05
                                                                         _getCL ());
     final IReadableResource INVOICE_UBL_PEPPOL_SB = new ClassPathResource (PREFIX_XSLT + "PEPPOL-EN16931-UBL-SB.xslt",
                                                                            _getCL ());
-    final IReadableResource ORDER = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T01.xslt", _getCL ());
-    final IReadableResource DESPATCH_ADVICE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T16.xslt", _getCL ());
-    final IReadableResource CATALOGUE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T19.xslt", _getCL ());
-    final IReadableResource CATALOGUE_RESPONSE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T58.xslt", _getCL ());
-    final IReadableResource MLR = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T71.xslt", _getCL ());
-    final IReadableResource ORDER_RESPONSE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T76.xslt", _getCL ());
-    final IReadableResource PUNCH_OUT = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T77.xslt", _getCL ());
-    final IReadableResource ORDER_AGREEMENT = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T110.xslt", _getCL ());
-    final IReadableResource INVOICE_MESSAGE_RESPONSE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T111.xslt",
-                                                                              _getCL ());
-    final IReadableResource ORDER_CHANGE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T114.xslt", _getCL ());
-    final IReadableResource ORDER_CANCELLATION = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T115.xslt", _getCL ());
-    final IReadableResource ORDER_RESPONSE_ADVANCED = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T116.xslt",
-                                                                             _getCL ());
 
     // Peppol BIS Billing 3.0.21
     VesXmlBuilder.builder ()
@@ -158,6 +148,32 @@ public final class PeppolValidation2026_05
                  .addSchematron (PhiveRulesUBLHelper.createXSLT_UBL21 (INVOICE_UBL_CEN))
                  .addSchematron (PhiveRulesUBLHelper.createXSLT_UBL21 (INVOICE_UBL_PEPPOL_SB))
                  .registerInto (aRegistry);
+  }
+
+  public static void init (@NonNull final IValidationExecutorSetRegistry <IValidationSourceXML> aRegistry)
+  {
+    ValueEnforcer.notNull (aRegistry, "Registry");
+    initBilling (aRegistry);
+
+    final String sVersion = " (" + VERSION_STR + ")";
+    // See https://docs.peppol.eu/poacc/upgrade-3/release-notes/
+    final String sAkaVersionBIS = " (aka BIS 3.0.17)";
+
+    final String PREFIX_XSLT = "external/schematron/openpeppol/" + VERSION_STR + "/xslt/";
+    final IReadableResource ORDER = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T01.xslt", _getCL ());
+    final IReadableResource DESPATCH_ADVICE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T16.xslt", _getCL ());
+    final IReadableResource CATALOGUE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T19.xslt", _getCL ());
+    final IReadableResource CATALOGUE_RESPONSE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T58.xslt", _getCL ());
+    final IReadableResource MLR = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T71.xslt", _getCL ());
+    final IReadableResource ORDER_RESPONSE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T76.xslt", _getCL ());
+    final IReadableResource PUNCH_OUT = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T77.xslt", _getCL ());
+    final IReadableResource ORDER_AGREEMENT = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T110.xslt", _getCL ());
+    final IReadableResource INVOICE_MESSAGE_RESPONSE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T111.xslt",
+                                                                              _getCL ());
+    final IReadableResource ORDER_CHANGE = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T114.xslt", _getCL ());
+    final IReadableResource ORDER_CANCELLATION = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T115.xslt", _getCL ());
+    final IReadableResource ORDER_RESPONSE_ADVANCED = new ClassPathResource (PREFIX_XSLT + "PEPPOLBIS-T116.xslt",
+                                                                             _getCL ());
 
     // Peppol BIS 3.0.17 (Upgrade-3 / Post-Award)
     VesXmlBuilder.builder ()

--- a/phive-rules-peppol/src/main/java/com/helger/phive/peppol/PeppolValidationBisEurope.java
+++ b/phive-rules-peppol/src/main/java/com/helger/phive/peppol/PeppolValidationBisEurope.java
@@ -67,4 +67,20 @@ public final class PeppolValidationBisEurope
     PeppolValidation2026_03.init (aRegistry);
     PeppolValidation2026_05.init (aRegistry);
   }
+
+  /**
+   * Register only the supported Peppol BIS Billing and Self-Billing validation execution sets.
+   *
+   * @param aRegistry
+   *        The registry to add the artefacts. May not be <code>null</code>.
+   */
+  public static void initBilling (@NonNull final IValidationExecutorSetRegistry <IValidationSourceXML> aRegistry)
+  {
+    ValueEnforcer.notNull (aRegistry, "Registry");
+
+    PeppolValidation2025_05.initBilling (aRegistry);
+    PeppolValidation2025_11.initBilling (aRegistry);
+    PeppolValidation2026_03.initBilling (aRegistry);
+    PeppolValidation2026_05.initBilling (aRegistry);
+  }
 }

--- a/phive-rules-peppol/src/test/java/com/helger/phive/peppol/PeppolValidationBillingTest.java
+++ b/phive-rules-peppol/src/test/java/com/helger/phive/peppol/PeppolValidationBillingTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2014-2026 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.phive.peppol;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import com.helger.phive.api.executorset.ValidationExecutorSetRegistry;
+import com.helger.phive.xml.source.IValidationSourceXML;
+
+public final class PeppolValidationBillingTest
+{
+  @Test
+  public void testSingleReleaseBillingOnly ()
+  {
+    final ValidationExecutorSetRegistry <IValidationSourceXML> aRegistry = new ValidationExecutorSetRegistry <> ();
+    PeppolValidation2025_05.initBilling (aRegistry);
+
+    assertEquals (2, aRegistry.getAll ().size ());
+    assertNotNull (aRegistry.getOfID (PeppolValidation2025_05.VID_OPENPEPPOL_INVOICE_UBL_V3));
+    assertNotNull (aRegistry.getOfID (PeppolValidation2025_05.VID_OPENPEPPOL_CREDIT_NOTE_UBL_V3));
+    assertNull (aRegistry.getOfID (PeppolValidation2025_05.VID_OPENPEPPOL_ORDER_V3));
+    assertNull (aRegistry.getOfID (PeppolValidation2025_05.VID_OPENPEPPOL_ORDER_CHANGE_V3));
+  }
+
+  @Test
+  public void testAllSupportedBillingOnly ()
+  {
+    final ValidationExecutorSetRegistry <IValidationSourceXML> aRegistry = new ValidationExecutorSetRegistry <> ();
+    PeppolValidationBisEurope.initBilling (aRegistry);
+
+    assertEquals (10, aRegistry.getAll ().size ());
+    assertNotNull (aRegistry.getOfID (PeppolValidation2025_11.VID_OPENPEPPOL_INVOICE_UBL_V3));
+    assertNotNull (aRegistry.getOfID (PeppolValidation2026_03.VID_OPENPEPPOL_INVOICE_SELF_BILLING_UBL_V3));
+    assertNotNull (aRegistry.getOfID (PeppolValidation2026_05.VID_OPENPEPPOL_CREDIT_NOTE_SELF_BILLING_UBL_V3));
+    assertNull (aRegistry.getOfID (PeppolValidation2026_05.VID_OPENPEPPOL_ORDER_RESPONSE_ADVANCED_V3));
+  }
+}


### PR DESCRIPTION
Fixes #83.

This adds a backwards-compatible narrow registration path for applications that validate only Peppol Billing documents:

- `initBilling` on the combined European release classes
- `PeppolValidationBisEurope.initBilling` across supported releases
- existing `init` methods still register the same complete set, in the same order
- focused tests verify the exact billing-only contents and absence of post-award/order sets

Why this matters: our ReAI service selects only the invoice and credit-note validation IDs. With this API it can exclude `ph-ubl23`, whose 3.79 MiB model is used only by order change, order cancellation, and advanced order response, and avoid initializing all unrelated validator sets at startup.

Verification:

- all 7 `phive-rules-peppol` tests pass on JDK 25
- Maven `verify` passes
- a runtime smoke test called `PeppolValidation2025_05.initBilling` with `ph-ubl23` physically removed from the classpath and registered exactly two validation sets